### PR TITLE
feat(renderer): add TiledImage open failure handler

### DIFF
--- a/packages/renderer/src/elements/TiledImage.ts
+++ b/packages/renderer/src/elements/TiledImage.ts
@@ -83,13 +83,17 @@ class TiledImage extends Base {
         throw new Error('Either tileSource or url should be defined')
       }
     } catch (error) {
-      this.handleError(error)
+      this.handleError(error as Error)
     }
   }
 
-  private handleError(error: unknown): void {
-    if (this.props?.onOpenTiledImageFailed) {
-      this.props.onOpenTiledImageFailed(error)
+  private handleError(error: Error): void {
+    const viewer = this._parent?.viewer
+    if (viewer) {
+      viewer.raiseEvent('open-failed', {
+        eventSource: viewer,
+        message: error?.message ? error?.message : error,
+      })
     } else {
       throw error
     }

--- a/packages/renderer/src/types/index.ts
+++ b/packages/renderer/src/types/index.ts
@@ -40,7 +40,6 @@ export interface TiledImageProps extends NodeProps {
   url?: string
   tileUrlBase?: string
   tileSource?: OpenSeadragon.TileSource
-  onOpenTiledImageFailed?: (error: any) => void
 }
 
 export interface ViewportEventHandlers

--- a/packages/renderer/src/types/index.ts
+++ b/packages/renderer/src/types/index.ts
@@ -40,6 +40,7 @@ export interface TiledImageProps extends NodeProps {
   url?: string
   tileUrlBase?: string
   tileSource?: OpenSeadragon.TileSource
+  onOpenTiledImageFailed?: (error: any) => void
 }
 
 export interface ViewportEventHandlers


### PR DESCRIPTION
## 📝 Description

> 1. added 'onOpenTiledImageFailed' to TiledImage component
>> There wasn't any error handling logic in TiledImage component,
>> So any error that is thrown during image loading process(e.g. fetch error of loading dzi metadata process) could cause unexpected unmounting behavior.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

## 🚀 New behavior

> If onOpenTiledImageFailed exists in props, it throw error to the handler, otherwise it just throws as before.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
